### PR TITLE
Add llvm-toolchain-precise-3.7

### DIFF
--- a/ubuntu.json
+++ b/ubuntu.json
@@ -40,6 +40,11 @@
     "key_url": "http://llvm.org/apt/llvm-snapshot.gpg.key"
   },
   {
+    "alias": "llvm-toolchain-precise-3.7",
+    "sourceline": "deb http://llvm.org/apt/precise/ llvm-toolchain-precise-3.7 main",
+    "key_url": "http://llvm.org/apt/llvm-snapshot.gpg.key"
+  },
+  {
     "alias": "lucid",
     "sourceline": "deb http://archive.ubuntu.com/ubuntu/ lucid main",
     "key_url": null


### PR DESCRIPTION
It is useful to test against llvm-trunk nightlies to fix up breaking changes and report bugs as they happen instead of all at once after a whole new cycle. 