### PR TITLE
add mariadb-10.0

### DIFF
--- a/ubuntu.json
+++ b/ubuntu.json
@@ -80,6 +80,11 @@
     "key_url": null
   },
   {
+    "alias": "mariadb-10.0",
+    "sourceline": "deb https://downloads.mariadb.com/files/MariaDB/repo/10.0/ubuntu precise main",
+    "key_url": "https://downloads.mariadb.com/files/MariaDB/repo/10.0/ubuntu/dists/precise/Release.gpg"
+  },
+  {
     "alias": "mongodb-upstart",
     "sourceline": "deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen",
     "key_url": "http://keyserver.ubuntu.com/pks/lookup?op=get&fingerprint=on&search=0x9ECBEC467F0CEB10"

--- a/ubuntu.json
+++ b/ubuntu.json
@@ -82,7 +82,7 @@
   {
     "alias": "mariadb-10.0",
     "sourceline": "deb https://downloads.mariadb.com/files/MariaDB/repo/10.0/ubuntu precise main",
-    "key_url": "https://downloads.mariadb.com/files/MariaDB/repo/10.0/ubuntu/dists/precise/Release.gpg"
+    "key_url": "http://keyserver.ubuntu.com/pks/lookup?op=get&fingerprint=on&search=0x1BB943DB"
   },
   {
     "alias": "mongodb-upstart",

--- a/ubuntu.json
+++ b/ubuntu.json
@@ -81,7 +81,7 @@
   },
   {
     "alias": "mariadb-10.0",
-    "sourceline": "deb https://downloads.mariadb.com/files/MariaDB/repo/10.0/ubuntu precise main",
+    "sourceline": "deb http://ftp.osuosl.org/pub/mariadb/repo/10.0/ubuntu precise main",
     "key_url": "http://keyserver.ubuntu.com/pks/lookup?op=get&fingerprint=on&search=0x1BB943DB"
   },
   {


### PR DESCRIPTION
Needed for a jemalloc-3.0+ to get a container based travis-ci build going for mariadb.

According to https://mariadb.com/kb/en/mariadb/building-mariadb-release-on-ubuntu-1204-lts-precise-pangolin it has fixes (which I assume are upstream now).

From http://www.ubuntuupdates.org/pm/jemalloc it seems that the PPA mariadb-5.5 and Percona Server with XtraDB also have a jemalloc-3.0+ for precise. I've just chosen the later version of mariadb-10 as it closer to the what I intend to build it for and I may end up using galera from this same repository.