### PR TITLE
Add george-edison55/cmake-3.x for cmake 3 support

### DIFF
--- a/ubuntu.json
+++ b/ubuntu.json
@@ -55,6 +55,11 @@
     "key_url": null
   },
   {
+    "alias": "george-edison55-precise-cmake",
+    "sourceline": "ppa:george-edison55/cmake-3.x",
+    "key_url": null
+  },
+  {
     "alias": "george-edison55-precise-backports",
     "sourceline": "ppa:george-edison55/precise-backports",
     "key_url": null

--- a/ubuntu.json
+++ b/ubuntu.json
@@ -55,13 +55,13 @@
     "key_url": null
   },
   {
-    "alias": "george-edison55-precise-cmake",
-    "sourceline": "ppa:george-edison55/cmake-3.x",
+    "alias": "george-edison55-precise-backports",
+    "sourceline": "ppa:george-edison55/precise-backports",
     "key_url": null
   },
   {
-    "alias": "george-edison55-precise-backports",
-    "sourceline": "ppa:george-edison55/precise-backports",
+    "alias": "george-edison55-cmake",
+    "sourceline": "ppa:george-edison55/cmake-3.x",
     "key_url": null
   },
   {

--- a/ubuntu.json
+++ b/ubuntu.json
@@ -55,13 +55,13 @@
     "key_url": null
   },
   {
-    "alias": "george-edison55-precise-backports",
-    "sourceline": "ppa:george-edison55/precise-backports",
+    "alias": "george-edison55-cmake",
+    "sourceline": "ppa:george-edison55/cmake-3.x",
     "key_url": null
   },
   {
-    "alias": "george-edison55-cmake",
-    "sourceline": "ppa:george-edison55/cmake-3.x",
+    "alias": "george-edison55-precise-backports",
+    "sourceline": "ppa:george-edison55/precise-backports",
     "key_url": null
   },
   {


### PR DESCRIPTION
The reason why I personally want cmake 3 support is for the [ninja-build](https://martine.github.io/ninja/) generator.

EDIT: I realized this ppa does not support precise and that cmake 2.8.11 supports ninja just fine.