### PR TITLE
Add FPComplete repositories to enable stack/Haskell builds

### DIFF
--- a/ubuntu.json
+++ b/ubuntu.json
@@ -50,6 +50,21 @@
     "key_url": "http://download.fpcomplete.com/ubuntu/fpco.key"
   },
   {
+    "alias": "fpcomplete-stable-trusty",
+    "sourceline": "deb http://download.fpcomplete.com/ubuntu/trusty stable main",
+    "key_url": "http://download.fpcomplete.com/ubuntu/fpco.key"
+  },
+  {
+    "alias": "fpcomplete-stable-utopic",
+    "sourceline": "deb http://download.fpcomplete.com/ubuntu/utopic stable main",
+    "key_url": "http://download.fpcomplete.com/ubuntu/fpco.key"
+  },
+  {
+    "alias": "fpcomplete-stable-vivid",
+    "sourceline": "deb http://download.fpcomplete.com/ubuntu/vivid stable main",
+    "key_url": "http://download.fpcomplete.com/ubuntu/fpco.key"
+  },
+  {
     "alias": "gammu",
     "sourceline": "ppa:nijel/ppa",
     "key_url": null

--- a/ubuntu.json
+++ b/ubuntu.json
@@ -45,6 +45,11 @@
     "key_url": "http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x16126D3A3E5C1192"
   },
   {
+    "alias": "fpcomplete-stable-precise",
+    "sourceline": "deb http://download.fpcomplete.com/ubuntu/precise stable main",
+    "key_url": "http://download.fpcomplete.com/ubuntu/fpco.key"
+  },
+  {
     "alias": "gammu",
     "sourceline": "ppa:nijel/ppa",
     "key_url": null


### PR DESCRIPTION
This is to allow installation of [stack](https://github.com/commercialhaskell/stack) tooling via apt addons - which can then be used to build Haskell jobs in the new container-based infrastructure.

/cc @snoyberg, @manny-fp