### PR TITLE
Added the MongoDB 3 repo to the whitelist

### DIFF
--- a/ubuntu.json
+++ b/ubuntu.json
@@ -114,7 +114,6 @@
     "sourceline": "deb http://repo.mongodb.org/apt/ubuntu precise/mongodb-org/3.0 multiverse",
     "key_url": "http://keyserver.ubuntu.com/pks/lookup?op=get&fingerprint=on&search=0x9ECBEC467F0CEB10"
   },
-  }
   {
     "alias": "mopidy-stable",
     "sourceline": "deb http://apt.mopidy.com/ stable main contrib non-free",

--- a/ubuntu.json
+++ b/ubuntu.json
@@ -104,7 +104,7 @@
     "sourceline": "deb http://ftp.osuosl.org/pub/mariadb/repo/10.0/ubuntu precise main",
     "key_url": "http://keyserver.ubuntu.com/pks/lookup?op=get&fingerprint=on&search=0x1BB943DB"
   },
-    {
+  {
     "alias": "mongodb-precise",
     "sourceline": "deb http://repo.mongodb.org/apt/ubuntu precise/mongodb-org/3.0 multiverse",
     "key_url": "http://keyserver.ubuntu.com/pks/lookup?op=get&fingerprint=on&search=0x9ECBEC467F0CEB10"

--- a/ubuntu.json
+++ b/ubuntu.json
@@ -104,14 +104,14 @@
     "sourceline": "deb http://ftp.osuosl.org/pub/mariadb/repo/10.0/ubuntu precise main",
     "key_url": "http://keyserver.ubuntu.com/pks/lookup?op=get&fingerprint=on&search=0x1BB943DB"
   },
-  {
-    "alias": "mongodb-upstart",
-    "sourceline": "deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen",
+    {
+    "alias": "mongodb-precise",
+    "sourceline": "deb http://repo.mongodb.org/apt/ubuntu precise/mongodb-org/3.0 multiverse",
     "key_url": "http://keyserver.ubuntu.com/pks/lookup?op=get&fingerprint=on&search=0x9ECBEC467F0CEB10"
   },
   {
-    "alias": "mongodb-precise",
-    "sourceline": "deb http://repo.mongodb.org/apt/ubuntu precise/mongodb-org/3.0 multiverse",
+    "alias": "mongodb-upstart",
+    "sourceline": "deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen",
     "key_url": "http://keyserver.ubuntu.com/pks/lookup?op=get&fingerprint=on&search=0x9ECBEC467F0CEB10"
   },
   {

--- a/ubuntu.json
+++ b/ubuntu.json
@@ -110,6 +110,12 @@
     "key_url": "http://keyserver.ubuntu.com/pks/lookup?op=get&fingerprint=on&search=0x9ECBEC467F0CEB10"
   },
   {
+    "alias": "mongodb-precise",
+    "sourceline": "deb http://repo.mongodb.org/apt/ubuntu precise/mongodb-org/3.0 multiverse",
+    "key_url": "http://keyserver.ubuntu.com/pks/lookup?op=get&fingerprint=on&search=0x9ECBEC467F0CEB10"
+  },
+  }
+  {
     "alias": "mopidy-stable",
     "sourceline": "deb http://apt.mopidy.com/ stable main contrib non-free",
     "key_url": "https://apt.mopidy.com/mopidy.gpg"


### PR DESCRIPTION
This is required for MongoEngine in order to move to the new infrastrucutre.