### PR TITLE
- add OpenBuildService repo

### DIFF
--- a/ubuntu.json
+++ b/ubuntu.json
@@ -173,5 +173,10 @@
     "alias": "ubuntu-toolchain-r-test",
     "sourceline": "ppa:ubuntu-toolchain-r/test",
     "key_url": null
+  },
+  {
+    "alias": "obs-unstable",
+    "sourceline": "deb http://download.opensuse.org/repositories/OBS:/Server:/Unstable/xUbuntu_12.04 obs-unstable main",
+    "key_url": null
   }
 ]


### PR DESCRIPTION
required to test against adapted/fixed versions of createrepo and friends

This will allow us to switch to the new container workers with https://github.com/openSUSE/open-build-service hopefully.