### PR TITLE
Add ppa:dartsim/ppa to the whitelist

### DIFF
--- a/ubuntu.json
+++ b/ubuntu.json
@@ -30,6 +30,11 @@
     "key_url": "http://packages.couchbase.com/ubuntu/couchbase.key"
   },
   {
+    "alias": "dartsim",
+    "sourceline": "ppa:dartsim/ppa",
+    "key_url": null
+  },
+  {
     "alias": "deadsnakes",
     "sourceline": "ppa:fkrull/deadsnakes",
     "key_url": null


### PR DESCRIPTION
This pull request adds [ppa:dartsim/ppa](https://launchpad.net/~dartsim/+archive/ubuntu/ppa/+packages) to the whitelist.

The PPA provides:
- assimp - 3.0~dfsg-1
- console-bridge - 0.2.4-0ppa1~precise2
- flann - 1.8.4-2
- tinyxml2 - 0~git20120518.1.a2ae54e-1
- urdfdom - 0.2.8+dfsg-0ppa2~precise2
- urdfdom-headers - 0.2.3+dfsg-0ppa1
