### PR TITLE
Add ppa:fcl-debs/ppa to the whitelist

### DIFF
--- a/ubuntu.json
+++ b/ubuntu.json
@@ -45,6 +45,11 @@
     "key_url": "http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x16126D3A3E5C1192"
   },
   {
+    "alias": "fcl",
+    "sourceline": "ppa:fcl-debs/ppa",
+    "key_url": null
+  },
+  {
     "alias": "gammu",
     "sourceline": "ppa:nijel/ppa",
     "key_url": null


### PR DESCRIPTION
This pull request adds [ppa:fcl-debs/ppa](https://launchpad.net/~fcl-debs/+archive/ubuntu/ppa) to the whitelist.

The PPA provides `fcl - 0.2.9-0~ppa3~precise1`.
