### PR TITLE
Add ppa:libccd-debs/ppa to the whitelist

### DIFF
--- a/ubuntu.json
+++ b/ubuntu.json
@@ -75,6 +75,11 @@
     "key_url": null
   },
   {
+    "alias": "libccd",
+    "sourceline": "ppa:libccd-debs/ppa",
+    "key_url": null
+  },
+  {
     "alias": "llvm-toolchain-precise",
     "sourceline": "deb http://llvm.org/apt/precise/ llvm-toolchain-precise main",
     "key_url": "http://llvm.org/apt/llvm-snapshot.gpg.key"


### PR DESCRIPTION
This pull request adds [ppa:libccd-debs/ppa](https://launchpad.net/~libccd-debs/+archive/ubuntu/ppa) to the whitelist.

The PPA provides `libccd - 1.4-0~ppa1~precise1`.
