### PR TITLE
Add ppa:vala-team/ppa to the source whitelist

### DIFF
--- a/ubuntu.json
+++ b/ubuntu.json
@@ -328,5 +328,10 @@
     "alias": "ubuntu-toolchain-r-test",
     "sourceline": "ppa:ubuntu-toolchain-r/test",
     "key_url": null
+  },
+  {
+    "alias": "vala-team",
+    "sourceline": "ppa:vala-team/ppa",
+    "key_url": null
   }
 ]


### PR DESCRIPTION
Fix issue #42 by providing the PPA under the 'vala-team' alias.
