### PR TITLE
Add Ubuntu 14.04 PPA for vips 7.40.6 backport

### DIFF
--- a/ubuntu.json
+++ b/ubuntu.json
@@ -40,11 +40,6 @@
     "key_url": "https://ftp-master.debian.org/keys/archive-key-7.0.asc"
   },
   {
-    "alias": "extras-precise",
-    "sourceline": "deb http://extras.ubuntu.com/ubuntu precise main",
-    "key_url": "http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x16126D3A3E5C1192"
-  },
-  {
     "alias": "elasticsearch-1.6",
     "sourceline": "deb http://packages.elastic.co/elasticsearch/1.6/debian stable main",
     "key_url": "https://packages.elastic.co/GPG-KEY-elasticsearch"
@@ -53,6 +48,11 @@
     "alias": "elasticsearch-1.7",
     "sourceline": "deb http://packages.elastic.co/elasticsearch/1.7/debian stable main",
     "key_url": "https://packages.elastic.co/GPG-KEY-elasticsearch"
+  },
+  {
+    "alias": "extras-precise",
+    "sourceline": "deb http://extras.ubuntu.com/ubuntu precise main",
+    "key_url": "http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x16126D3A3E5C1192"
   },
   {
     "alias": "gammu",

--- a/ubuntu.json
+++ b/ubuntu.json
@@ -190,6 +190,11 @@
     "key_url": null
   },
   {
+    "alias": "trusty-backport-vips",
+    "sourceline": "ppa:lovell/trusty-backport-vips",
+    "key_url": null
+  },
+  {
     "alias": "ubuntu-sdk-team",
     "sourceline": "ppa:ubuntu-sdk-team/ppa",
     "key_url": null


### PR DESCRIPTION
Hello, this fixes #68 by adding support for my [trusty-backport-vips](https://launchpad.net/~lovell/+archive/ubuntu/trusty-backport-vips) PPA containing the 7.40.6 version of vips backported from vivid.

A number of paying Travis CI customers (e.g. @gasi @nordisk) are currently stuck installing vips and its dependencies via the old Ubuntu 12.04 sudo-based infrastructure. This change will allow them to access the newer, faster 14.04 container infrastructure thereby reducing the overall load on Travis CI systems.

If required, the full vips changelog is available at https://github.com/jcupitt/libvips/blob/master/ChangeLog