### PR TITLE
Add ppa:chris-lea/libsodium to the whitelist

### DIFF
--- a/ubuntu.json
+++ b/ubuntu.json
@@ -90,6 +90,11 @@
     "key_url": null
   },
   {
+    "alias": "libsodium",
+    "sourceline": "ppa:chris-lea/libsodium",
+    "key_url": null
+  },
+  {
     "alias": "llvm-toolchain-precise",
     "sourceline": "deb http://llvm.org/apt/precise/ llvm-toolchain-precise main",
     "key_url": "http://llvm.org/apt/llvm-snapshot.gpg.key"


### PR DESCRIPTION
Fixes #122.
This pull request adds
https://launchpad.net/~chris-lea/+archive/ubuntu/libsodium to the
whitelist.

The PPA provides:

- libsodium 1.0.3