### PR TITLE
Add Qt 5.0-5.5 ppa's to white list

### DIFF
--- a/ubuntu.json
+++ b/ubuntu.json
@@ -245,32 +245,32 @@
     "key_url": null
   },
   {
-    "alias": "qt502",
+    "alias": "qt502-precise",
     "sourceline": "ppa:beineri/opt-qt502",
     "key_url": null
   },
   {
-    "alias": "qt511",
+    "alias": "qt511-precise",
     "sourceline": "ppa:beineri/opt-qt511",
     "key_url": null
   },
   {
-    "alias": "qt521",
+    "alias": "qt521-precise",
     "sourceline": "ppa:beineri/opt-qt521",
     "key_url": null
   },
   {
-    "alias": "qt532",
+    "alias": "qt532-precise",
     "sourceline": "ppa:beineri/opt-qt532",
     "key_url": null
   },
   {
-    "alias": "qt542",
+    "alias": "qt542-precise",
     "sourceline": "ppa:beineri/opt-qt542",
     "key_url": null
   },
   {
-    "alias": "qt551",
+    "alias": "qt551-precise",
     "sourceline": "ppa:beineri/opt-qt551",
     "key_url": null
   },  

--- a/ubuntu.json
+++ b/ubuntu.json
@@ -245,6 +245,36 @@
     "key_url": null
   },
   {
+    "alias": "qt502",
+    "sourceline": "ppa:beineri/opt-qt502",
+    "key_url": null
+  },
+  {
+    "alias": "qt511",
+    "sourceline": "ppa:beineri/opt-qt511",
+    "key_url": null
+  },
+  {
+    "alias": "qt521",
+    "sourceline": "ppa:beineri/opt-qt521",
+    "key_url": null
+  },
+  {
+    "alias": "qt532",
+    "sourceline": "ppa:beineri/opt-qt532",
+    "key_url": null
+  },
+  {
+    "alias": "qt542",
+    "sourceline": "ppa:beineri/opt-qt542",
+    "key_url": null
+  },
+  {
+    "alias": "qt551",
+    "sourceline": "ppa:beineri/opt-qt551",
+    "key_url": null
+  },  
+  {
     "alias": "r-packages-precise",
     "sourceline": "deb http://cran.rstudio.com/bin/linux/ubuntu precise/",
     "key_url": "http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x51716619E084DAB9"


### PR DESCRIPTION
Add ppa:beineri/opt-qt502, ppa:beineri/opt-qt511, ppa:beineri/opt-qt521,
ppa:beineri/opt-qt532, ppa:beineri/opt-qt542, ppa:beineri/opt-qt551 to white list.

This commit is required to migrate Qt based projects from legacy infrastructure to
container-based infrastructure.

Fix issues: #27, #69, #110, #143