### PR TITLE
Add ARM Embedded GCC toolchain to whitelist #132

### DIFF
--- a/ubuntu.json
+++ b/ubuntu.json
@@ -270,8 +270,8 @@
     "key_url": "https://www.rabbitmq.com/rabbitmq-signing-key-public.asc"
   },
   {
-    "alias" : "team-gcc-arm-embedded",
-    "sourceline" : "ppa:team-gcc-arm-embedded/ppa",
+    "alias": "team-gcc-arm-embedded",
+    "sourceline": "ppa:team-gcc-arm-embedded/ppa",
     "key_url": null
   },
   {

--- a/ubuntu.json
+++ b/ubuntu.json
@@ -270,6 +270,11 @@
     "key_url": "https://www.rabbitmq.com/rabbitmq-signing-key-public.asc"
   },
   {
+    "alias" : "team-gcc-arm-embedded",
+    "sourceline" : "ppa:team-gcc-arm-embedded/ppa",
+    "key_url": null
+  },
+  {
     "alias": "tmate",
     "sourceline": "ppa:nviennot/tmate",
     "key_url": null


### PR DESCRIPTION
ARM toolchains have been asked multiple times as per #132
