### PR TITLE
Add git-core PPA to whitelist

### DIFF
--- a/ubuntu.json
+++ b/ubuntu.json
@@ -120,6 +120,11 @@
     "key_url": null
   },
   {
+    "alias": "git-core",
+    "sourceline": "ppa:git-core/ppa",
+    "key_url": null
+  },
+  {
     "alias": "google-chrome",
     "sourceline": "deb http://dl.google.com/linux/chrome/deb/ stable main",
     "key_url": "https://dl-ssl.google.com/linux/linux_signing_key.pub"


### PR DESCRIPTION
This enables people to install the latest Git version (currently 2.7) on the Travis CI Ubuntu Linux containers.

More info here:
https://launchpad.net/~git-core/+archive/ubuntu/ppa