### PR TITLE
Add avsm/ocaml*+opam* to whitelist

### DIFF
--- a/ubuntu.json
+++ b/ubuntu.json
@@ -45,6 +45,36 @@
     "key_url": null
   },
   {
+    "alias": "avsm-ocaml312-opam12",
+    "sourceline": "ppa:avsm/ocaml312+opam12",
+    "key_url": null
+  },
+  {
+    "alias": "avsm-ocaml40-opam12",
+    "sourceline": "ppa:avsm/ocaml40+opam12",
+    "key_url": null
+  },
+  {
+    "alias": "avsm-ocaml41-opam11",
+    "sourceline": "ppa:avsm/ocaml41+opam11",
+    "key_url": null
+  },
+  {
+    "alias": "avsm-ocaml41-opam12",
+    "sourceline": "ppa:avsm/ocaml41+opam12",
+    "key_url": null
+  },
+  {
+    "alias": "avsm-ocaml42-opam11",
+    "sourceline": "ppa:avsm/ocaml42+opam11",
+    "key_url": null
+  },
+  {
+    "alias": "avsm-ocaml42-opam12",
+    "sourceline": "ppa:avsm/ocaml42+opam12",
+    "key_url": null
+  },
+  {
     "alias": "boost-latest",
     "sourceline": "ppa:boost-latest/ppa",
     "key_url": null


### PR DESCRIPTION
Fixes #83 

```
$ bin/travis-add-source ubuntu.json avsm-ocaml41-opam11 ppa:avsm/ocaml41+opam11 "" -i
$ bin/travis-add-source ubuntu.json avsm-ocaml42-opam11 ppa:avsm/ocaml42+opam11 "" -i
$ bin/travis-add-source ubuntu.json avsm-ocaml42-opam12 ppa:avsm/ocaml42+opam12 "" -i
$ bin/travis-add-source ubuntu.json avsm-ocaml41-opam12 ppa:avsm/ocaml41+opam12 "" -i
$ bin/travis-add-source ubuntu.json avsm-ocaml40-opam12 ppa:avsm/ocaml40+opam12 "" -i
$ bin/travis-add-source ubuntu.json avsm-ocaml312-opam12 ppa:avsm/ocaml312+opam12 "" -i
```