### PR TITLE
Add Qt 5.X LTS and most recent versions 

### DIFF
--- a/ubuntu.json
+++ b/ubuntu.json
@@ -345,6 +345,21 @@
     "key_url": null
   },
   {
+    "alias": "qt5.10.1",
+    "sourceline": "ppa:beineri/opt-qt-5.10.1-trusty",
+    "key_url": null
+  },
+  {
+    "alias": "qt5.6.3",
+    "sourceline": "ppa:beineri/opt-qt563-trusty",
+    "key_url": null
+  },
+  {
+    "alias": "qt5.9.4",
+    "sourceline": "ppa:beineri/opt-qt594-trusty",
+    "key_url": null
+  },
+  {
     "alias": "r-packages-precise",
     "sourceline": "deb http://cran.rstudio.com/bin/linux/ubuntu precise/",
     "key_url": "http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x51716619E084DAB9"


### PR DESCRIPTION
This adds Qt PPAs to allow for Qt-based projects to move off of legacy architectures.
This commit supercedes #212 as it had test errors.

``` bash
bin/travis-add-source ubuntu.json qt5.6.3 ppa:beineri/opt-qt563-trusty '' -i
bin/travis-add-source ubuntu.json qt5.9.4 ppa:beineri/opt-qt594-trusty '' -i
bin/travis-add-source ubuntu.json qt5.10.1 ppa:beineri/opt-qt-5.10.1-trusty '' -i
```

Closes: #27, #69, #110, #143, #212

*Update:* This now only includes the most recent release and LTS versions. I've removed older ones, Qt is not small and I can understand why some may not want to have all the versions. 
