### PR TITLE
APT source whitelist updates for Chef repos

### DIFF
--- a/ubuntu.json
+++ b/ubuntu.json
@@ -56,13 +56,23 @@
   },
   {
     "alias": "chef-current-precise",
-    "sourceline": "deb https://packagecloud.io/chef/current/ubuntu/ precise main",
-    "key_url": "https://packagecloud.io/gpg.key"
+    "sourceline": "deb https://packages.chef.io/current-apt precise main",
+    "key_url": "https://downloads.chef.io/packages-chef-io-public.key"
   },
   {
     "alias": "chef-stable-precise",
-    "sourceline": "deb https://packagecloud.io/chef/stable/ubuntu/ precise main",
-    "key_url": "https://packagecloud.io/gpg.key"
+    "sourceline": "deb https://packages.chef.io/stable-apt precise main",
+    "key_url": "https://downloads.chef.io/packages-chef-io-public.key"
+  },
+  {
+    "alias": "chef-current-trusty",
+    "sourceline": "deb https://packages.chef.io/current-apt trusty main",
+    "key_url": "https://downloads.chef.io/packages-chef-io-public.key"
+  },
+  {
+    "alias": "chef-stable-trusty",
+    "sourceline": "deb https://packages.chef.io/stable-apt trusty main",
+    "key_url": "https://downloads.chef.io/packages-chef-io-public.key"
   },
   {
     "alias": "couchbase-precise",


### PR DESCRIPTION
Chef Software Inc’s existing PackageCloud APT repo has been deprecated. The new packages.chef.io APT repo has equivalent versions for all products and should be a drop in replacement.

See the following Chef mailing list post for full details:
https://discourse.chef.io/t/we-ve-moved-our-software-distribution-to-packages-chef-io/8001