### PR TITLE
Add google-cloud repo

### DIFF
--- a/ubuntu.json
+++ b/ubuntu.json
@@ -140,6 +140,11 @@
     "key_url": "https://dl-ssl.google.com/linux/linux_signing_key.pub"
   },
   {
+    "alias": "google-cloud",
+    "sourceline": "deb http://packages.cloud.google.com/apt trusty main",
+    "key_url": "https://packages.cloud.google.com/apt/doc/apt-key.gpg"
+  },
+  {
     "alias": "heroku",
     "sourceline": "deb http://toolbelt.heroku.com/ubuntu ./",
     "key_url": "https://toolbelt.heroku.com/apt/release.key"


### PR DESCRIPTION
Taken from https://cloud.google.com/sdk/#deb

The goal here is to allow users of the [Google App Engine deployment provider](https://github.com/travis-ci/dpl/blob/master/lib/dpl/provider/gae.rb) to install Google's Cloud SDK using the APT addon. I initially wrote a mail to support which ended up being handled by @BanzaiMan, him saying that:

> We are happy to accommodate this whitelist request, ...

This is the corresponding pull requests.

Build is failing because some other entries are not sorted, not my fault. Should I fix it?

CC: @waprin