### PR TITLE
Add tobydox/mingw-x-precise

### DIFF
--- a/ubuntu.json
+++ b/ubuntu.json
@@ -300,6 +300,11 @@
     "key_url": null
   },
   {
+    "alias": "tobydox-mingw-x-precise",
+    "sourceline": "ppa:tobydox/mingw-x-precise",
+    "key_url": null
+  },
+  {
     "alias": "travis-ci/sqlite3",
     "sourceline": "ppa:travis-ci/sqlite3",
     "key_url": null


### PR DESCRIPTION
This PPA contains fairly complete MinGW libraries (even contains Qt) that required to do a cross-compile to Windows target on a Linux host (Ubuntu Precise)