### PR TITLE
Add llvm-toolchain-trusty* for trusty llvm packages

### DIFF
--- a/ubuntu.json
+++ b/ubuntu.json
@@ -195,6 +195,21 @@
     "key_url": "http://llvm.org/apt/llvm-snapshot.gpg.key"
   },
   {
+    "alias": "llvm-toolchain-trusty",
+    "sourceline": "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty main",
+    "key_url": "http://apt.llvm.org/llvm-snapshot.gpg.key"
+  },
+  {
+    "alias": "llvm-toolchain-trusty-3.8",
+    "sourceline": "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-3.8 main",
+    "key_url": "http://apt.llvm.org/llvm-snapshot.gpg.key"
+  },
+  {
+    "alias": "llvm-toolchain-trusty-3.9",
+    "sourceline": "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-3.9 main",
+    "key_url": "http://apt.llvm.org/llvm-snapshot.gpg.key"
+  },
+  {
     "alias": "lucid",
     "sourceline": "deb http://archive.ubuntu.com/ubuntu/ lucid main",
     "key_url": null


### PR DESCRIPTION
follows #288 urls.
Also related (and potentially requirng merge fuzzy matching) #300 
