### PR TITLE
Add Yarn repo

### DIFF
--- a/ubuntu.json
+++ b/ubuntu.json
@@ -328,5 +328,10 @@
     "alias": "ubuntu-toolchain-r-test",
     "sourceline": "ppa:ubuntu-toolchain-r/test",
     "key_url": null
+  },
+  {
+    "alias": "yarn",
+    "sourceline": "deb http://dl.yarnpkg.com/debian/ stable main",
+    "key_url": "http://dl.yarnpkg.com/debian/pubkey.gpg"
   }
 ]


### PR DESCRIPTION
Adds repo for [Yarn](https://yarnpkg.com/), a new package manager for JavaScript.

Closes #321