### PR TITLE
APT source whitelist updates for Chef repos

### DIFF
--- a/ubuntu.json
+++ b/ubuntu.json
@@ -56,23 +56,23 @@
   },
   {
     "alias": "chef-current-precise",
-    "sourceline": "deb https://packages.chef.io/current-apt precise main",
-    "key_url": "https://downloads.chef.io/packages-chef-io-public.key"
+    "sourceline": "deb https://packages.chef.io/repos/apt/current precise main",
+    "key_url": "https://packages.chef.io/chef.asc"
   },
   {
     "alias": "chef-current-trusty",
-    "sourceline": "deb https://packages.chef.io/current-apt trusty main",
-    "key_url": "https://downloads.chef.io/packages-chef-io-public.key"
+    "sourceline": "deb https://packages.chef.io/repos/apt/current trusty main",
+    "key_url": "https://packages.chef.io/chef.asc"
   },
   {
     "alias": "chef-stable-precise",
-    "sourceline": "deb https://packages.chef.io/stable-apt precise main",
-    "key_url": "https://downloads.chef.io/packages-chef-io-public.key"
+    "sourceline": "deb https://packages.chef.io/repos/apt/stable precise main",
+    "key_url": "https://packages.chef.io/chef.asc"
   },
   {
     "alias": "chef-stable-trusty",
-    "sourceline": "deb https://packages.chef.io/stable-apt trusty main",
-    "key_url": "https://downloads.chef.io/packages-chef-io-public.key"
+    "sourceline": "deb https://packages.chef.io/repos/apt/stable trusty main",
+    "key_url": "https://packages.chef.io/chef.asc"
   },
   {
     "alias": "couchbase-precise",


### PR DESCRIPTION
We have made a few changes to our APT repos here at Chef Software Inc and it would be good to have these updates reflected on Travis!

Signed-off-by: Seth Chisamore <schisamo@chef.io>