### PR TITLE
Add ZeroC Ice repository for trusty

### DIFF
--- a/ubuntu.json
+++ b/ubuntu.json
@@ -328,5 +328,10 @@
     "alias": "ubuntu-toolchain-r-test",
     "sourceline": "ppa:ubuntu-toolchain-r/test",
     "key_url": null
+  },
+  {
+    "alias": "zeroc-trusty",
+    "sourceline": "deb http://zeroc.com/download/apt/ubuntu14.04 stable main",
+    "key_url": "http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x5E6DA83306132997"
   }
 ]


### PR DESCRIPTION
ZeroC Ice is packaged in Ubuntu (`zeroc-ice`), but the version is old and unsupported, making use of these package for Travis testing problematic.  This repository provides the latest stable release [directly from the upstream developers](https://zeroc.com/distributions/ice#ubuntu), which is what we would like to test against.

We use this in the `openmicroscopy` project extensively.  Currently we are forced to use the precise Ice 3.4 version in our [travis configuration](https://github.com/openmicroscopy/openmicroscopy/blob/develop/.travis.yml#L22) but this is no longer supported upstream for many years, nor by ourselves, and we need a newer version to be able to continue to use Travis for testing on the container-based infrastructure.

If you could consider whitelisting this repository, it would be greatly appreciated.


Many thanks,
Roger