### PR TITLE
Add gcc-arm-embedded repository

### DIFF
--- a/ubuntu.json
+++ b/ubuntu.json
@@ -135,6 +135,11 @@
     "key_url": null
   },
   {
+    "alias": "gcc-arm-embedded",
+    "sourceline": "ppa:team-gcc-arm-embedded/ppa",
+    "key_url": null
+  },
+  {
     "alias": "gearman-developers",
     "sourceline": "ppa:gearman-developers/ppa",
     "key_url": null


### PR DESCRIPTION
This is needed to cross-compile for `arm-none-eabi`.