### PR TITLE
Add ppa:webupd8team/java

### DIFF
--- a/ubuntu.json
+++ b/ubuntu.json
@@ -338,5 +338,10 @@
     "alias": "ubuntu-toolchain-r-test",
     "sourceline": "ppa:ubuntu-toolchain-r/test",
     "key_url": null
+  },
+  {
+    "alias": "webupd8team-java",
+    "sourceline": "ppa:webupd8team/java",
+    "key_url": null
   }
 ]


### PR DESCRIPTION
Since oracle-java(7|8)-installer is in https://github.com/travis-ci/apt-package-whitelist/blob/20c4d7da617bf5b239e9f1083e4f904d722f06f3/ubuntu-trusty#L1963