### PR TITLE
Add cmake-3.x for more recent versions of cmake

### DIFF
--- a/ubuntu.json
+++ b/ubuntu.json
@@ -78,7 +78,7 @@
     "alias": "cmake-3.x",
     "sourceline": "ppa:george-edison55/cmake-3.x",
     "key_url": null
-  }
+  },
   {
     "alias": "couchbase-precise",
     "sourceline": "deb http://packages.couchbase.com/ubuntu precise precise/main",

--- a/ubuntu.json
+++ b/ubuntu.json
@@ -75,6 +75,11 @@
     "key_url": "https://downloads.chef.io/packages-chef-io-public.key"
   },
   {
+    "alias": "cmake-3.x",
+    "sourceline": "ppa:george-edison55/cmake-3.x",
+    "key_url": null
+  }
+  {
     "alias": "couchbase-precise",
     "sourceline": "deb http://packages.couchbase.com/ubuntu precise precise/main",
     "key_url": "http://packages.couchbase.com/ubuntu/couchbase.key"


### PR DESCRIPTION
From the PPA description at https://launchpad.net/~george-edison55/+archive/ubuntu/cmake-3.x:

> Provides up to date builds of CMake 3.x (and related packages) for recent releases of Ubuntu. This currently includes:
>
> * 14.04 - Trusty Tahr
> * 15.10 - Wily Werewolf
> * 16.04 - Xenial Xerus
>
> All packages are built for i386, amd64, arm64, and armhf.
>
> These builds were created by taking the packages for CMake 3.x from Debian releases and backporting them and are considered stable.