### PR TITLE
The ubuntu-sdk-team moved qt5 packages

### DIFF
--- a/ubuntu.json
+++ b/ubuntu.json
@@ -353,5 +353,10 @@
     "alias": "ubuntu-toolchain-r-test",
     "sourceline": "ppa:ubuntu-toolchain-r/test",
     "key_url": null
+  },
+  {
+    "alias": "ubuntu1204-qt5",
+    "sourceline": "ppa:canonical-qt5-edgers/ubuntu1204-qt5",
+    "key_url": null
   }
 ]


### PR DESCRIPTION
The ubuntu-sdk-team have moved their qt5 packages to a new location which is breaking my builds. I use travis container infrastructure.

See https://launchpad.net/~ubuntu-sdk-team/+archive/ubuntu/ppa for details. 

>Old Ubuntu 12.04 LTS Qt 5.0 packages have been moved to https://launchpad.net/~canonical-qt5-edgers/+archive/ubuntu/ubuntu1204-qt5/

I propose the new source is added so I can update my .travis.yml accordingly.

(https://github.com/GilesBathgate/RapCAD/blob/master/.travis.yml)