### PR TITLE
Adding a PPA for yosys

### DIFF
--- a/ubuntu.json
+++ b/ubuntu.json
@@ -388,5 +388,10 @@
     "alias": "ubuntu-toolchain-r-test",
     "sourceline": "ppa:ubuntu-toolchain-r/test",
     "key_url": null
+  },
+  {
+    "alias": "yosys",
+    "sourceline": "ppa:saltmakrell/ppa",
+    "key_url": null
   }
 ]


### PR DESCRIPTION
Yosys is included in the latest debian / Ubuntu but not in the older
version used on Travis.

---

Yosys is a framework for Verilog RTL synthesis. It currently has
extensive Verilog-2005 support and provides a basic set of synthesis
algorithms for various application domains. Selected features and
typical applications:

 * Process almost any synthesizable Verilog-2005 design
 * Converting Verilog to BLIF / EDIF/ BTOR / SMT-LIB / simple RTL
   Verilog / etc.
 * Built-in formal methods for checking properties and equivalence
 * Mapping to ASIC standard cell libraries (in Liberty File Format)
 * Mapping to Xilinx 7-Series and Lattice iCE40 FPGAs
 * Foundation and/or front-end for custom flows

Yosys can be adapted to perform any synthesis job by combining the
existing passes (algorithms) using synthesis scripts and adding
additional passes as needed by extending the Yosys C++ code base.

Yosys is free software licensed under the ISC license (a GPL compatible
license that is similar in terms to the MIT license or the 2-clause BSD
license).