### PR TITLE
added mongodb-3.6-(precise|trusty)

### DIFF
--- a/ubuntu.json
+++ b/ubuntu.json
@@ -310,6 +310,16 @@
     "key_url": "http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x0C49F3730359A14518585931BC711F9BA15703C6"
   },
   {
+    "alias": "mongodb-3.6-precise",
+    "sourceline": "deb [arch=amd64] http://repo.mongodb.org/apt/ubuntu precise/mongodb-org/3.6 multiverse",
+    "key_url": "https://www.mongodb.org/static/pgp/server-3.6.asc"
+  },
+  {
+    "alias": "mongodb-3.6-trusty",
+    "sourceline": "deb [arch=amd64] http://repo.mongodb.org/apt/ubuntu trusty/mongodb-org/3.6 multiverse",
+    "key_url": "http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x0C49F3730359A14518585931BC711F9BA15703C6"
+  },
+  {
     "alias": "mongodb-upstart",
     "sourceline": "deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen",
     "key_url": "http://keyserver.ubuntu.com/pks/lookup?op=get&fingerprint=on&search=0x9ECBEC467F0CEB10"


### PR DESCRIPTION
please merge mongodb-3.6 as there are some changes between interfacing with 3.4 and 3.6 with mongodb which needs to be tested.

thanks in advance.